### PR TITLE
chatlight: fix the Claude Code exporter, which crashed on every session

### DIFF
--- a/tools/chatlight.md
+++ b/tools/chatlight.md
@@ -18,9 +18,11 @@ A chat is ephemeral until someone pulls it into daylight. Chatlight reads the ra
 
 ## Platform Detection
 
-Detect which IDE is running:
-- **Cursor**: The workspace has a `.cursor/` directory and state.vscdb exists at the platform-specific path
-- **Claude Code**: The workspace has a `.claude/` directory and session JSONL files exist at `~/.claude/projects/`
+Detect by which session store actually holds data, not by which dotfile directory exists - a workspace can contain both `.cursor/` and `.claude/`:
+- **Cursor**: state.vscdb exists at the platform-specific path and contains a `composerData:` row
+- **Claude Code**: `~/.claude/projects/<sanitized-path>/` exists and contains `.jsonl` files
+
+If both stores hold data for the workspace, ask which to export.
 
 Write only the matching `<python>` block's content to a .py file (strip the fence markers). Run it. File the output.
 
@@ -28,24 +30,26 @@ Write only the matching `<python>` block's content to a .py file (strip the fenc
 
 ## Invocation
 
-Accept 1-2 arguments:
-1. **Chat UUID** (required) - the session to export. If omitted, use the most recent session (highest mtime)
-2. **Output file path** (optional) - where to write the markdown. Default: derive from chat title
+Both arguments are positional and optional:
+1. **Chat UUID** - the session to export. If omitted, use the most recent session (highest mtime)
+2. **Output file path** - where to write the markdown. Default: derive from chat title
+
+The Claude Code script also accepts `--branch live|longest` (see Rewinds) and `--force` to overwrite an existing output file. Its progress and skip report goes to stderr.
 
 ### Finding the current chat UUID
 
 **Cursor:** List directories in `~/.cursor/projects/{project-slug}/agent-transcripts/`. Sort by mtime descending. The most recent directory name is the chat UUID. The project-slug derives from the workspace path by replacing path separators and colons with dashes (e.g. `c:\Users\Vinnie\src\cursor` becomes `c-Users-Vinnie-src-cursor`).
 
-**Claude Code:** List `.jsonl` files in `~/.claude/projects/<sanitized-path>/`. Sort by mtime descending. The most recent filename (without `.jsonl`) is the session UUID. The sanitized path replaces `/` with `-` and URL-encodes special chars (e.g. `/home/user/myapp` becomes `-home-user-myapp`).
+**Claude Code:** List `.jsonl` files in `~/.claude/projects/<sanitized-path>/`. Sort by mtime descending. The most recent filename (without `.jsonl`) is the session UUID. The sanitized path is the absolute workspace path with both `/` and `.` replaced by `-` (e.g. `/home/user/my.app` becomes `-home-user-my-app`).
 
 ---
 
 ## Execution
 
 1. Detect the platform
-2. Extract the code from inside the matching `<python>` block - strip the opening and closing triple-backtick fence lines, write only the Python source to a scratch .py file
+2. Extract the code from inside the matching `<python>` block - strip the opening and closing triple-backtick fence lines, write only the Python source to a scratch .py file. Extract it programmatically; do not retype it
 3. Run the script with the chat UUID and output path
-4. Verify the first user message in the output matches what you see in the chat
+4. Read the stderr report. It states how many user messages, agent responses and subagent summaries were exported, and lists every category of event that was skipped. If it prints a `WARNING`, act on it before filing the output
 5. File the markdown as **output**: `chatlight-{chat-name-slug}.md`
 
 The .py file is **scratch**.
@@ -79,7 +83,7 @@ Agent response.
 ```
 
 Rules:
-- H1 heading with chat title at top (Cursor: `composerHeaders.name`; Claude Code: first 6 words of first user message)
+- H1 heading with chat title at top (Cursor: `composerHeaders.name`; Claude Code: the session's own `ai-title` event, falling back to the first 6 words of the first user message)
 - `---` before every user message (including the first)
 - User text in blockquote (`> ` prefix on each line)
 - One blank line between every element
@@ -89,15 +93,26 @@ Rules:
 - `---` after the final agent response (end-of-file marker)
 - Empty text bubbles (text field is `""`) produce no output - skip silently
 
+### Claude Code specifics
+
+**Message shape.** `message.content` is a bare string for anything the human typed and a block list for tool results and richer turns. Handle both.
+
+**Plumbing.** Much of what is stored under `type: "user"` was never typed. `<system-reminder>` blocks carry injected context (CLAUDE.md, memory, environment) and are stripped from within the surrounding message, since a real message can wrap one. `<task-notification>`, `<local-command-*>` envelopes, `isMeta` events and `tool_result` blocks are dropped whole. A slash command arrives wrapped in `<command-name>`/`<command-args>`; the user did type it, so it is unwrapped to the `/command args` line.
+
+**Rewinds.** The JSONL is an append-only tree, not a flat log, so reading it linearly replays abandoned branches as real conversation. Follow `parentUuid` from a leaf to the root. `--branch live` (default) starts from the newest leaf, which is what the UI shows; `--branch longest` starts from the deepest, for when a rewind left the substance on a branch the UI no longer displays. If more events are skipped than exported, the script warns and names the flag.
+
+**Subagents.** A synchronous agent returns its report as the `tool_result`. A background agent returns only a launch stub naming an internal `agentId`; the real report arrives in a later `<task-notification>` and is spooled to a file that is deleted when the session ends. Resolve in that order, strip the `agentId` and any trailing `<usage>` block, and expect older sessions to report `no summary available`.
+
 ---
 
 ## Success Criteria
 
-- The output contains every user message and every visible agent response from the session, in order
+- The output contains every user message and every visible agent response from the surviving branch, in order
 - No thinking text appears
 - No tool-call metadata appears (except subagent summaries)
+- No harness plumbing appears - no `<system-reminder>`, no `<task-notification>`, no internal `agentId`
 - The markdown renders cleanly in any viewer
-- Before filing the output, confirm the first user message matches what you see in the chat
+- The script exits 0. Any lossy outcome is counted and reported on stderr rather than passed off as a complete export
 
 ---
 
@@ -335,150 +350,286 @@ if __name__ == "__main__":
 ```
 """
 Chatlight - Claude Code export
-Usage: python chatlight_claude.py <session-uuid> <output-path>
+Usage: python chatlight_claude.py [session-uuid] [output-path] [--branch live|longest] [--force]
 
-Reads JSONL session file, walks events, writes clean markdown.
-Exit 0 on success, 1 on failure.
+Reads JSONL session file, walks the surviving conversation branch, writes clean markdown.
+With no session-uuid, exports the most recent session. Exit 0 on success, 1 on failure.
 """
 import sys
 import os
+import re
 import json
 import glob as globmod
 
+LAUNCH_STUB = "Async agent launched successfully"
+
+# Envelopes the harness injects under type "user" that the human never typed.
+DROP_PREFIXES = (
+    "<local-command-stdout>",
+    "<local-command-caveat>",
+    "<task-notification>",
+    "<command-message>",
+    "<command-args>",
+    "<system-reminder>",
+    "[Request interrupted",
+)
+SYSTEM_REMINDER = re.compile(r"<system-reminder>.*?</system-reminder>", re.DOTALL)
+COMMAND_NAME = re.compile(r"<command-name>(.*?)</command-name>", re.DOTALL)
+COMMAND_ARGS = re.compile(r"<command-args>(.*?)</command-args>", re.DOTALL)
+AGENT_ID = re.compile(r"^agentId:.*$", re.MULTILINE)
+USAGE = re.compile(r"<usage>.*?</usage>", re.DOTALL)
+TOOL_USE_ID = re.compile(r"<tool-use-id>(.*?)</tool-use-id>", re.DOTALL)
+OUTPUT_FILE = re.compile(r"<output-file>(.*?)</output-file>", re.DOTALL)
+
+
+def die(msg):
+    print(f"Error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def texts(content):
+    """Text strings in a message.content, which is a bare string for anything
+    the human typed and a block list for tool results and richer turns."""
+    if isinstance(content, str):
+        return [content]
+    if not isinstance(content, list):
+        return []
+    return [
+        b["text"]
+        for b in content
+        if isinstance(b, dict) and b.get("type") == "text" and isinstance(b.get("text"), str)
+    ]
+
+
+def clean(text):
+    """Visible user text, or "" if the whole message was harness plumbing."""
+    text = SYSTEM_REMINDER.sub("", text).strip()
+    if not text:
+        return ""
+    name = COMMAND_NAME.search(text)
+    if name:  # a slash command the user did type: render it as typed
+        args = COMMAND_ARGS.search(text)
+        return f"{name.group(1).strip()} {args.group(1).strip() if args else ''}".strip()
+    if text.startswith(DROP_PREFIXES):
+        return ""
+    return text
+
+
+def branch(events, mode):
+    """Events on one conversation branch, newest-leaf ("live") or deepest ("longest").
+
+    The JSONL is an append-only tree: rewinds and edited messages leave abandoned
+    branches, so reading it linearly replays dead ones as real conversation.
+    """
+    by_uuid = {e["uuid"]: e for e in events if isinstance(e.get("uuid"), str)}
+    ordered = [e for e in events if isinstance(e.get("uuid"), str)]
+    if not ordered:
+        return events, 0
+
+    def walk(leaf):
+        chain, seen, node = [], set(), leaf
+        while node is not None and node.get("uuid") not in seen:
+            seen.add(node.get("uuid"))
+            chain.append(node)
+            parent = node.get("parentUuid")
+            if not parent:
+                return chain[::-1]
+            node = by_uuid.get(parent)
+        return chain[::-1] if node is None else None
+
+    if mode == "longest":
+        parents = {e.get("parentUuid") for e in ordered}
+        chains = [walk(e) for e in ordered if e.get("uuid") not in parents]
+        chain = max((c for c in chains if c), key=len, default=None)
+    else:
+        chain = walk(ordered[-1])
+
+    if chain is None:  # broken chain (compaction, partial file): keep file order
+        return events, 0
+    return chain, len(ordered) - len(chain)
+
+
+def subagent_map(events):
+    """Agent/Task tool_use_id -> (description, summary).
+
+    Synchronous agents return the report as the tool_result. Background agents
+    return only a launch stub naming an internal agentId; the real report arrives
+    in a later <task-notification> and is spooled to a file that is deleted when
+    the session ends. Never emit the agentId.
+    """
+    calls, results, spools = {}, {}, {}
+    for ev in events:
+        content = (ev.get("message") or {}).get("content")
+        if ev.get("type") == "assistant" and isinstance(content, list):
+            for b in content:
+                if isinstance(b, dict) and b.get("type") == "tool_use" and b.get("name") in ("Task", "Agent"):
+                    inp = b.get("input") or {}
+                    calls[b.get("id")] = str(inp.get("description") or b.get("name")).strip()
+        if ev.get("type") != "user":
+            continue
+        if isinstance(content, list):
+            for b in content:
+                if isinstance(b, dict) and b.get("type") == "tool_result":
+                    raw = b.get("content", "")
+                    if isinstance(raw, list):
+                        raw = "\n".join(x.get("text", "") for x in raw if isinstance(x, dict))
+                    results[b.get("tool_use_id")] = raw if isinstance(raw, str) else ""
+        for text in texts(content):
+            tid = TOOL_USE_ID.search(text) if "<task-notification>" in text else None
+            if tid:
+                out = OUTPUT_FILE.search(text)
+                spools[tid.group(1).strip()] = out.group(1).strip() if out else ""
+
+    out = {}
+    for tid, desc in calls.items():
+        summary = results.get(tid, "")
+        if not summary or LAUNCH_STUB in summary:
+            path = spools.get(tid, "")
+            summary = ""
+            if path and os.path.isfile(path):
+                try:
+                    with open(path, encoding="utf-8", errors="replace") as f:
+                        summary = f.read()
+                except OSError:
+                    summary = ""
+        out[tid] = (desc, USAGE.sub("", AGENT_ID.sub("", summary)).strip())
+    return out
+
+
+def render(events, title, mode):
+    live, pruned = branch(events, mode)
+    subs = subagent_map(live)
+    lines = [f"# {title}", ""]
+    n = {"user": 0, "agent": 0, "sub": 0, "nosub": 0, "plumbing": 0, "meta": 0}
+
+    for ev in live:
+        content = (ev.get("message") or {}).get("content")
+        if ev.get("isSidechain"):
+            continue
+
+        if ev.get("type") == "user":
+            if ev.get("isMeta"):
+                n["meta"] += 1
+                continue
+            parts = [p for p in (clean(t) for t in texts(content)) if p]
+            if isinstance(content, list) and any(
+                isinstance(b, dict) and b.get("type") == "image" for b in content
+            ):
+                parts.append("*[image attached]*")
+            if not parts:
+                n["plumbing"] += 1 if texts(content) else 0
+                continue
+            n["user"] += 1
+            lines += ["---", ""]
+            lines += [f"> {ln}" if ln else ">" for ln in "\n\n".join(parts).split("\n")]
+            lines.append("")
+
+        elif ev.get("type") == "assistant" and isinstance(content, list):
+            body = [b["text"] for b in content if b.get("type") == "text" and b.get("text", "").strip()]
+            if body:
+                n["agent"] += 1
+                lines += ["\n".join(body), ""]
+            for b in content:
+                if b.get("type") != "tool_use" or b.get("id") not in subs:
+                    continue
+                desc, summary = subs[b["id"]]
+                if summary:
+                    n["sub"] += 1
+                    lines += [f"*[Subagent: {desc}]*", "", summary, ""]
+                else:
+                    n["nosub"] += 1
+                    lines += [f"*[Subagent: {desc} - no summary available]*", ""]
+
+    return "\n".join(lines + ["---", ""]), n, pruned, len(live)
+
+
 def main():
-    if len(sys.argv) < 3:
-        print("Usage: python chatlight_claude.py <session-uuid> <output-path>", file=sys.stderr)
-        sys.exit(1)
+    argv = sys.argv[1:]
+    force = "--force" in argv
+    mode = "live"
+    if "--branch" in argv:
+        i = argv.index("--branch")
+        mode = argv[i + 1] if i + 1 < len(argv) else ""
+        if mode not in ("live", "longest"):
+            die("--branch must be 'live' or 'longest'")
+        del argv[i : i + 2]
+    args = [a for a in argv if not a.startswith("--")]
+    uuid = args[0] if args else None
+    output_path = args[1] if len(args) > 1 else None
 
-    session_uuid = sys.argv[1]
-    output_path = sys.argv[2]
+    root = os.path.expanduser("~/.claude/projects")
+    if not os.path.isdir(root):
+        die(f"Claude Code projects directory not found at {root}")
+    if uuid:
+        found = globmod.glob(os.path.join(root, "*", f"{uuid}.jsonl"))
+        if not found:
+            die(f"Session file not found for UUID '{uuid}'")
+        session_path = found[0]
+    else:
+        found = globmod.glob(os.path.join(root, "*", "*.jsonl"))
+        if not found:
+            die("No session files found")
+        session_path = max(found, key=os.path.getmtime)
 
-    # Locate session file
-    claude_dir = os.path.expanduser("~/.claude/projects")
-    if not os.path.isdir(claude_dir):
-        print(f"Error: Claude Code projects directory not found at {claude_dir}", file=sys.stderr)
-        sys.exit(1)
-
-    # Search all project dirs for the session UUID
-    session_path = None
-    for project_dir in globmod.glob(os.path.join(claude_dir, "*")):
-        candidate = os.path.join(project_dir, f"{session_uuid}.jsonl")
-        if os.path.isfile(candidate):
-            session_path = candidate
-            break
-
-    if session_path is None:
-        print(f"Error: Session file not found for UUID '{session_uuid}'", file=sys.stderr)
-        sys.exit(1)
-
-    # Read all events
-    events = []
-    with open(session_path, "r", encoding="utf-8") as f:
+    events, bad = [], 0
+    with open(session_path, encoding="utf-8", errors="replace") as f:
         for line in f:
-            line = line.strip()
-            if line:
+            if line.strip():
                 try:
                     events.append(json.loads(line))
                 except json.JSONDecodeError:
-                    continue
-
+                    bad += 1
     if not events:
-        print(f"Error: No events found in session file", file=sys.stderr)
-        sys.exit(1)
+        die(f"No events found in {session_path}")
 
-    # Derive title from first user message (first 6 words)
-    chat_title = "Untitled Chat"
-    for ev in events:
-        if ev.get("type") == "user":
-            msg = ev.get("message", {})
-            content_blocks = msg.get("content", [])
-            for block in content_blocks:
-                if block.get("type") == "text":
-                    words = block["text"].split()[:6]
-                    chat_title = " ".join(words)
-                    break
-            break
+    title = next(
+        (e["aiTitle"].strip() for e in reversed(events)
+         if e.get("type") == "ai-title" and (e.get("aiTitle") or "").strip()),
+        None,
+    )
+    if not title:
+        first = next(
+            (c for e in branch(events, mode)[0] if e.get("type") == "user" and not e.get("isMeta")
+             for c in (clean(t) for t in texts((e.get("message") or {}).get("content"))) if c),
+            "",
+        )
+        title = " ".join(first.split()[:6]) or "Untitled Chat"
 
-    lines = []
-    lines.append(f"# {chat_title}")
-    lines.append("")
+    markdown, n, pruned, kept = render(events, title, mode)
+    if not n["user"] and not n["agent"]:
+        die(f"No conversation content found in {session_path}")
 
-    # Build tool_use_id -> subagent summary map
-    tool_results = {}
-    for ev in events:
-        if ev.get("type") == "user":
-            msg = ev.get("message", {})
-            for block in msg.get("content", []):
-                if block.get("type") == "tool_result":
-                    tool_use_id = block.get("tool_use_id", "")
-                    result_content = block.get("content", "")
-                    if isinstance(result_content, list):
-                        text_parts = [b.get("text", "") for b in result_content if b.get("type") == "text"]
-                        result_content = "\n".join(text_parts)
-                    tool_results[tool_use_id] = result_content
-
-    for ev in events:
-        ev_type = ev.get("type")
-
-        if ev_type == "user":
-            msg = ev.get("message", {})
-            content_blocks = msg.get("content", [])
-            user_text_parts = []
-            for block in content_blocks:
-                if block.get("type") == "text":
-                    user_text_parts.append(block["text"])
-            if user_text_parts:
-                text = "\n".join(user_text_parts)
-                lines.append("---")
-                lines.append("")
-                for line in text.split("\n"):
-                    lines.append(f"> {line}")
-                lines.append("")
-
-        elif ev_type == "assistant":
-            msg = ev.get("message", {})
-            content_blocks = msg.get("content", [])
-            text_parts = []
-            subagent_calls = []
-
-            for block in content_blocks:
-                if block.get("type") == "text":
-                    text_parts.append(block["text"])
-                elif block.get("type") == "tool_use":
-                    name = block.get("name", "")
-                    if name in ("Task", "Agent"):
-                        tool_id = block.get("id", "")
-                        desc = block.get("input", {}).get("description", name)
-                        summary = tool_results.get(tool_id, "")
-                        subagent_calls.append((desc, summary))
-
-            if text_parts:
-                lines.append("\n".join(text_parts))
-                lines.append("")
-
-            for desc, summary in subagent_calls:
-                if summary:
-                    lines.append(f"*[Subagent: {desc}]*")
-                    lines.append("")
-                    lines.append(summary)
-                    lines.append("")
-                else:
-                    lines.append(f"*[Subagent: {desc} - no summary available]*")
-                    lines.append("")
-
-    # End-of-file marker
-    lines.append("---")
-    lines.append("")
-
+    if output_path is None:
+        slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")[:60] or "untitled"
+        output_path = f"chatlight-{slug}.md"
+    if os.path.exists(output_path) and not force:
+        die(f"{output_path} already exists (use --force to overwrite)")
     os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
     with open(output_path, "w", encoding="utf-8") as f:
-        f.write("\n".join(lines))
+        f.write(markdown)
 
-    print(f"Exported: {chat_title} -> {output_path}")
+    # Report losses. Silent truncation reads as "exported everything".
+    print(f"Exported: {title} -> {output_path}", file=sys.stderr)
+    print(f"  {n['user']} user, {n['agent']} agent, {n['sub']} subagent summaries", file=sys.stderr)
+    skipped = [
+        f"{v} {k}" for k, v in (
+            ("abandoned-branch events", pruned), ("injected/system messages", n["plumbing"]),
+            ("meta events", n["meta"]), ("unavailable subagent reports", n["nosub"]),
+            ("unparseable lines", bad),
+        ) if v
+    ]
+    if skipped:
+        print("  skipped: " + ", ".join(skipped), file=sys.stderr)
+    if mode == "live" and pruned > kept:
+        print(
+            f"  WARNING: skipped more events ({pruned}) than exported ({kept}); this session "
+            f"was rewound. Re-run with --branch longest for the fuller branch.",
+            file=sys.stderr,
+        )
     sys.exit(0)
+
 
 if __name__ == "__main__":
     main()
-
 ```
 </python>


### PR DESCRIPTION
- Handle `message.content` as a bare string as well as a block list. The string form is how a typed human message is stored, and it is the first user event in essentially every session, so the exporter hit an uncaught `AttributeError` during title derivation and exited 1 without writing anything. Even past that point the list-only path found 18 user text blocks across my 22 local sessions versus the 64 real messages that exist.
- Take the title from the session's own `ai-title` event rather than guessing six words from the first message, and follow `parentUuid` from a leaf to the root so rewinds and edited messages stop replaying abandoned branches as real conversation. `--branch longest` recovers sessions where the rewind left the substance off the live branch.
- Stop exporting harness plumbing as user speech: `<system-reminder>` (which carries injected CLAUDE.md, memory index and environment details), `<task-notification>`, `<local-command-*>` and `isMeta` events. Slash commands are unwrapped to the `/command args` line the user actually typed instead of being dropped or emitted as raw XML.
- Resolve background subagents through their task notification and spooled output file, instead of pasting the launch stub and the internal `agentId` it names. Strip the trailing `<usage>` metadata block the spooled report carries. Spooled reports are deleted when a session ends, so older sessions report `no summary available`.
- Count every loss on stderr, and refuse to overwrite an existing output file without `--force`, so a lossy export cannot look like a complete one.

The script grows 146 to 283 lines; prose is +14 net. I deliberately kept this to the fix and left out the convenience flags and verbose reporting from my first pass, which had the block at 521 lines for no correctness gain.

Testing: extracted the embedded block programmatically and ran it against 23 real local sessions, 23/23 exit 0 with output written; the current version exits 1 on all of them. The trimmed version is byte-identical to the longer one on all 23. Verified no thinking payload reaches the output by checking the contents of all 488 thinking blocks against every export, verified a background subagent report resolves end to end when its spool file still exists, and verified the rewind warning fires on the one session where it applies.

Two things left alone. The cursor block is untouched, since I have no Cursor install to test against; it does look to have separate problems, notably a `composerHeaders` table lookup whose `OperationalError` is swallowed, which would silently yield "Untitled Chat" rather than the documented `composerHeaders.name`. And `tools/chatlight.md` is not listed in README.md the way other tools are, which looks like a pre-existing gap but is outside the scope of a script fix.