### PR TITLE
Register plugin commands by directory

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,35 +1,15 @@
 {
   "name": "tools-public",
   "description": "Prompt-based tools and skills from the C++ Alliance",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "C++ Alliance",
     "url": "https://github.com/cppalliance"
   },
   "repository": "https://github.com/cppalliance/tools-public",
   "commands": [
-    "./tools/btc-talk.md",
-    "./tools/normalize-prompt.md",
-    "./tools/refine-plan.md",
-    "./tools/research.md",
-    "./tools/code/boost-review.md",
-    "./tools/code/code-cleanup.md",
-    "./tools/code/code-review.md",
-    "./tools/code/lib-review.md",
-    "./tools-wg21/advocatus.md",
-    "./tools-wg21/auditor.md",
-    "./tools-wg21/herald.md",
-    "./tools-wg21/is-this-cpp.md",
-    "./tools-wg21/review-paper.md",
-    "./tools-wg21/tighten.md",
-    "./tools/voice.md",
-    "./tools/voice/",
-    "./tools/interview.md",
-    "./tools/interview/",
-    "./tools/tutor.md",
-    "./tools/tutor/"
-  ],
-  "skills": [
-    "./tools-wg21/pick-pr-review/"
+    "./tools/",
+    "./tools/code/",
+    "./tools-wg21/"
   ]
 }


### PR DESCRIPTION
Replaces the per-file `commands` enumeration in `.claude-plugin/plugin.json` with the three tool directories:

```json
"commands": [
  "./tools/",
  "./tools/code/",
  "./tools-wg21/"
]
```

Claude Code scans directory entries for `.md` files non-recursively ([plugins reference](https://code.claude.com/docs/en/plugins-reference.md)), so any new tool dropped at the top level of these directories becomes a command automatically, with no manifest edit. The non-recursion also keeps support content (`voice/`, `interview/`, `tutor/`, `novelist/`, `retired/`, `slider/`) out of the command list. This picks up tools the old list had drifted away from, e.g. `tools/dokuman.md`.

Also:

- Drops the `./tools/voice/`, `./tools/interview/`, and `./tools/tutor/` entries. Those files are personas and protocols loaded by their parent tools, not standalone commands, and none of them surfaced as commands anyway (see below).
- Drops the `skills` field, since the PR associated with `pick-pr-review` was rejected. The auto-discovery fallback only looks in a root `skills/` directory, which does not exist, so nothing gets re-registered. The orphaned `tools-wg21/pick-pr-review/` directory itself is left for a separate decision.
- Bumps the version to 1.1.0 so existing installs pick up the change.

One caveat observed while testing the installed plugin: only files with a YAML front-matter `description:` block actually surfaced as invocable skills. Every manifest entry that starts straight at an H1 (`btc-talk`, `advocatus`, `voice`, `tutor`, `is-this-cpp`, `review-paper`, `normalize-prompt`) failed to load. So tools without front matter will not appear until they get a two-line `description:` block. That front-matter pass is left as a follow-up.